### PR TITLE
Add basic Next.js frontend

### DIFF
--- a/emi-landscape-frontend/.gitignore
+++ b/emi-landscape-frontend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+.env

--- a/emi-landscape-frontend/README.md
+++ b/emi-landscape-frontend/README.md
@@ -1,0 +1,10 @@
+# EMI Landscape Frontend
+
+This is a minimal Next.js 14 application with Tailwind CSS.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```

--- a/emi-landscape-frontend/next-env.d.ts
+++ b/emi-landscape-frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/messages/typescript-config

--- a/emi-landscape-frontend/next.config.js
+++ b/emi-landscape-frontend/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/emi-landscape-frontend/package.json
+++ b/emi-landscape-frontend/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "emi-landscape-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.0.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.0.0",
+    "eslint": "^8.0.0",
+    "eslint-config-next": "^14.0.4"
+  }
+}

--- a/emi-landscape-frontend/postcss.config.js
+++ b/emi-landscape-frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/emi-landscape-frontend/src/app/generate/page.tsx
+++ b/emi-landscape-frontend/src/app/generate/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+import { useState } from 'react';
+
+export default function GeneratePage() {
+  const [clientInput, setClientInput] = useState('');
+  const [photoDescription, setPhotoDescription] = useState('');
+  const [budget, setBudget] = useState('');
+  const [preferences, setPreferences] = useState('');
+  const [response, setResponse] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const res = await fetch('https://emi-landscape-backend.replit.app/generate-layout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          clientInput,
+          photoDescription,
+          budget,
+          preferences,
+        }),
+      });
+      const data = await res.json();
+      setResponse(data.response || JSON.stringify(data));
+    } catch (err) {
+      console.error(err);
+      setResponse('An error occurred');
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Generate Layout</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block mb-1">Client Input</label>
+          <textarea
+            value={clientInput}
+            onChange={(e) => setClientInput(e.target.value)}
+            className="w-full p-2 border rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Photo Description</label>
+          <textarea
+            value={photoDescription}
+            onChange={(e) => setPhotoDescription(e.target.value)}
+            className="w-full p-2 border rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Budget</label>
+          <input
+            type="text"
+            value={budget}
+            onChange={(e) => setBudget(e.target.value)}
+            className="w-full p-2 border rounded"
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Preferences</label>
+          <input
+            type="text"
+            value={preferences}
+            onChange={(e) => setPreferences(e.target.value)}
+            className="w-full p-2 border rounded"
+          />
+        </div>
+        <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded">
+          Submit
+        </button>
+      </form>
+      {response && (
+        <div className="mt-4">
+          <h2 className="text-xl font-bold mb-2">Response</h2>
+          <pre className="p-4 bg-gray-100 whitespace-pre-wrap">{response}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/emi-landscape-frontend/src/app/globals.css
+++ b/emi-landscape-frontend/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/emi-landscape-frontend/src/app/layout.tsx
+++ b/emi-landscape-frontend/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'EMI Landscape App',
+  description: 'EMI Landscape App',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/emi-landscape-frontend/src/app/page.tsx
+++ b/emi-landscape-frontend/src/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-24">
+      <h1 className="text-3xl font-bold">Welcome to EMI Landscape App</h1>
+    </main>
+  );
+}

--- a/emi-landscape-frontend/tailwind.config.js
+++ b/emi-landscape-frontend/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx,mdx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/emi-landscape-frontend/tsconfig.json
+++ b/emi-landscape-frontend/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create `emi-landscape-frontend` with Next.js 14 and Tailwind
- add homepage that welcomes users
- add `/generate` page with a form posting to backend and displaying response

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68684e0d39b88327855e79481ddb2539